### PR TITLE
✨ Build rv & ore from source (option)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# setup-ruby-flash Changelog Entry
+
+## [Unreleased]
+
+### Added
+
+- **Build from Source Support**: New `rv-git-ref` and `ore-git-ref` inputs allow building rv and ore from git branches, tags, or commits instead of using release binaries
+  - `rv-git-ref`: Build rv from any git reference (requires Rust, automatically installed)
+  - `ore-git-ref`: Build ore from any git reference (requires Go 1.24, automatically installed)
+  - Enables testing unreleased versions without creating formal releases
+  - Supports branches (`main`), tags (`v0.5.0-beta`), and commit SHAs
+  - Built binaries are cached by git ref for fast subsequent runs
+  - When git ref is set, corresponding version input (`rv-version`, `ore-version`) is ignored
+  - **Use Case**: Test PRs, feature branches, and bug fixes before release
+  - **Performance**: First build 3-5 min (rv) or 1-2 min (ore); cached builds ~1-2 sec
+  - See `GIT_REF_FEATURE.md` for comprehensive documentation and examples
+
+### Changed
+
+- Cache keys now include `build-from-source` flag to prevent collision between git refs and release versions
+- Improved version resolution to handle both release versions and git references
+
+### Notes
+
+- Building from source is intended for testing only; production CI should use release versions
+- Rust toolchain installed automatically for rv (via `dtolnay/rust-toolchain@stable`)
+- Go toolchain installed automatically for ore (via `actions/setup-go@v5` with `stable`)
+
+---
+
+## Usage Example
+
+Test unreleased ore fix:
+
+```yaml
+- uses: appraisal-rb/setup-ruby-flash@v1
+  with:
+    ruby-version: "3.4"
+    ore-install: true
+    ore-git-ref: "feat/bundle-gemfile-support" # Build from feature branch
+```
+
+Test rv pre-release:
+
+```yaml
+- uses: appraisal-rb/setup-ruby-flash@v1
+  with:
+    ruby-version: "3.4"
+    rv-git-ref: "v0.5.0-beta1" # Build from beta tag
+```

--- a/GIT_REF_FEATURE.md
+++ b/GIT_REF_FEATURE.md
@@ -1,0 +1,413 @@
+# Building rv and ore from Source - Feature Documentation
+
+## Overview
+
+setup-ruby-flash now supports building `rv` and `ore` from git branches, tags, or commits instead of using released binaries. This enables testing unreleased versions without creating formal releases.
+
+## New Inputs
+
+### `rv-git-ref`
+
+**Description**: Git branch, tag, or commit SHA to build rv from source.
+
+**When set**: rv will be built from the specified git ref instead of using a release binary.
+
+**Toolchain**: Rust toolchain is automatically installed if needed (via `dtolnay/rust-toolchain@stable`)
+
+**Examples**:
+
+- `'main'` - Build from main branch
+- `'feat/new-feature'` - Build from feature branch
+- `'v0.5.0-beta'` - Build from pre-release tag
+- `'abc123'` - Build from specific commit
+
+**Default**: `''` (empty - uses release binary)
+
+**Overrides**: When set, `rv-version` input is ignored
+
+### `ore-git-ref`
+
+**Description**: Git branch, tag, or commit SHA to build ore from source.
+
+**When set**: ore will be built from the specified git ref instead of using a release binary.
+
+**Toolchain**: Go toolchain is automatically installed if needed (via `actions/setup-go@v5` with `stable`)
+
+**Examples**:
+
+- `'main'` - Build from main branch
+- `'feat/bundle-gemfile-support'` - Build from feature branch
+- `'v0.19.0-alpha'` - Build from pre-release tag
+- `'def456'` - Build from specific commit
+
+**Default**: `''` (empty - uses release binary)
+
+**Overrides**: When set, `ore-version` input is ignored
+
+## Usage Examples
+
+### Example 1: Test BUNDLE_GEMFILE Fix in ore-light
+
+```yaml
+name: Test ore BUNDLE_GEMFILE fix
+
+on: [push, pull_request]
+
+jobs:
+  test-ore-fix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Ruby with ore from feature branch
+        uses: appraisal-rb/setup-ruby-flash@v1
+        with:
+          ruby-version: "3.4"
+          ore-install: true
+          ore-git-ref: "feat/bundle-gemfile-support" # Build from feature branch
+
+      - name: Verify ore respects BUNDLE_GEMFILE
+        env:
+          BUNDLE_GEMFILE: Appraisal.root.gemfile
+        run: |
+          ore install
+          # Should use Appraisal.root.gemfile instead of Gemfile
+```
+
+### Example 2: Test rv Pre-release
+
+```yaml
+name: Test rv beta
+
+on: [push]
+
+jobs:
+  test-rv-beta:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Ruby with rv beta
+        uses: appraisal-rb/setup-ruby-flash@v1
+        with:
+          ruby-version: "3.4"
+          rv-git-ref: "v0.5.0-beta1" # Build from beta tag
+
+      - name: Test with beta rv
+        run: |
+          rv --version
+          ruby --version
+```
+
+### Example 3: Test Both from Source
+
+```yaml
+name: Test unreleased rv and ore
+
+on: [workflow_dispatch]
+
+jobs:
+  test-both:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup with unreleased versions
+        uses: appraisal-rb/setup-ruby-flash@v1
+        with:
+          ruby-version: "3.4"
+          rv-git-ref: "main" # Latest rv from main
+          ore-install: true
+          ore-git-ref: "main" # Latest ore from main
+
+      - name: Verify installations
+        run: |
+          rv --version
+          ore --version
+          ruby --version
+```
+
+### Example 4: Test Specific Commit
+
+```yaml
+name: Test specific commit
+
+on: [push]
+
+jobs:
+  test-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup with specific ore commit
+        uses: appraisal-rb/setup-ruby-flash@v1
+        with:
+          ruby-version: "3.4"
+          ore-install: true
+          ore-git-ref: "a1b2c3d4e5f6" # Specific commit SHA
+```
+
+## How It Works
+
+### Build Process Flow
+
+#### For rv (Rust)
+
+1. **Cache Check**: Checks if binary for this git ref is cached
+2. **Rust Setup**: If not cached and `rv-git-ref` is set, installs Rust toolchain
+3. **Clone & Build**:
+
+   ```bash
+   git clone --depth 1 https://github.com/spinel-coop/rv.git
+   git checkout <rv-git-ref>  # fetches ref if needed
+   cargo build --release
+   cp target/release/rv ~/.local/bin/rv
+   rm -rf /tmp/rv-build  # cleanup
+   ```
+
+4. **Cache Store**: Binary is cached for subsequent runs
+
+#### For ore (Go)
+
+1. **Cache Check**: Checks if binary for this git ref is cached
+2. **Go Setup**: If not cached and `ore-git-ref` is set, installs Go (stable)
+3. **Clone & Build**:
+
+   ```bash
+   git clone --depth 1 https://github.com/contriboss/ore-light.git
+   git checkout <ore-git-ref>  # fetches ref if needed
+   go build -o ore ./cmd/ore
+   cp ore ~/.local/bin/ore
+   rm -rf /tmp/ore-build  # cleanup
+   ```
+
+4. **Cache Store**: Binary is cached for subsequent runs
+
+### Caching Strategy
+
+**Cache Key Format**:
+
+- rv: `setup-ruby-flash-rv-<platform>-<git-ref>-true`
+- ore: `setup-ruby-flash-ore-<platform>-<git-ref>-true`
+
+**Benefits**:
+
+- Git refs are cached separately from release versions
+- Same git ref on same platform reuses cached binary
+- `build-from-source=true` flag prevents collision with release binaries
+
+**Example Cache Keys**:
+
+- `setup-ruby-flash-rv-linux-amd64-main-true`
+- `setup-ruby-flash-ore-darwin-arm64-feat/bundle-gemfile-support-true`
+- `setup-ruby-flash-rv-linux-arm64-v0.5.0-beta-true`
+
+## Performance Considerations
+
+### First Run (No Cache)
+
+**With git ref** (builds from source):
+
+- rv: ~3-5 minutes (Rust compilation)
+- ore: ~1-2 minutes (Go compilation)
+
+**With release** (downloads binary):
+
+- rv: ~5-10 seconds
+- ore: ~5-10 seconds
+
+### Subsequent Runs (Cached)
+
+**Same for both**:
+
+- rv: ~1-2 seconds (cache restore)
+- ore: ~1-2 seconds (cache restore)
+
+### Recommendations
+
+1. **Use git refs for testing only** - Not recommended for production CI
+2. **Prefer release versions for speed** - When possible
+3. **Cache hits are fast** - Once built, git refs are as fast as releases
+4. **Pin commits for stability** - Use commit SHAs instead of branch names if consistency matters
+
+## Build Requirements
+
+### Automatically Installed When Needed
+
+#### For rv
+
+- ✅ Rust toolchain (via `dtolnay/rust-toolchain@stable`)
+- ✅ Cargo (comes with Rust)
+- ✅ git (pre-installed on GitHub runners)
+
+#### For ore
+
+- ✅ Go toolchain (via `actions/setup-go@v5` with `stable`)
+- ✅ git (pre-installed on GitHub runners)
+
+### Pre-installed on Runners
+
+- ✅ git
+- ✅ Standard build tools (make, gcc, etc.)
+
+## Troubleshooting
+
+### Build Fails - Invalid Git Ref
+
+**Error**:
+
+```text
+fatal: couldn't find remote ref feat/typo-branch
+```
+
+**Solution**: Verify the branch/tag exists in the repository
+
+### Build Fails - Compilation Error
+
+**Error**:
+
+```text
+error: could not compile `rv` (bin "rv")
+```
+
+**Solution**:
+
+- The git ref may be broken or incompatible
+- Try a different ref (e.g., latest release tag)
+- Check the rv/ore repository for known issues
+
+### Cache Not Working
+
+**Symptom**: Builds from source every time
+
+**Solution**:
+
+- Verify cache key is stable (don't use dynamic values in git-ref)
+- Check GitHub Actions cache limits (10GB per repo)
+- Consider using commit SHA instead of branch name for stability
+
+## Comparison: Git Ref vs Release
+
+| Aspect                | Git Ref                     | Release Binary     |
+| --------------------- | --------------------------- | ------------------ |
+| **Speed (first run)** | ❌ Slow (3-5 min)           | ✅ Fast (5-10 sec) |
+| **Speed (cached)**    | ✅ Fast (1-2 sec)           | ✅ Fast (1-2 sec)  |
+| **Use Case**          | Testing unreleased features | Production CI      |
+| **Stability**         | ⚠️ May be unstable          | ✅ Stable releases |
+| **Flexibility**       | ✅ Any commit/branch        | ❌ Only releases   |
+| **Setup Complexity**  | ⚠️ Requires toolchain       | ✅ Simple download |
+
+## Best Practices
+
+### ✅ DO
+
+- Use git refs for testing PRs and feature branches
+- Use commit SHAs for reproducible builds
+- Cache aggressively (same git ref = same binary)
+- Document which git ref you're testing in workflow names
+
+### ❌ DON'T
+
+- Use git refs in production CI (slow first build)
+- Use dynamic branch names that change frequently
+- Forget to test with actual releases before merging
+- Mix git refs and release versions without clear reason
+
+## Migration Guide
+
+### From Release to Git Ref
+
+**Before**:
+
+```yaml
+- uses: appraisal-rb/setup-ruby-flash@v1
+  with:
+    ore-version: "0.18.0"
+    ore-install: true
+```
+
+**After**:
+
+```yaml
+- uses: appraisal-rb/setup-ruby-flash@v1
+  with:
+    ore-git-ref: "feat/bundle-gemfile-support" # ore-version ignored when ore-git-ref set
+    ore-install: true
+```
+
+### From Git Ref Back to Release
+
+**Before**:
+
+```yaml
+- uses: appraisal-rb/setup-ruby-flash@v1
+  with:
+    ore-git-ref: "feat/bundle-gemfile-support"
+    ore-install: true
+```
+
+**After**:
+
+```yaml
+- uses: appraisal-rb/setup-ruby-flash@v1
+  with:
+    ore-git-ref: "" # Clear git ref
+    ore-version: "latest" # Use latest release
+    ore-install: true
+```
+
+Or simply remove the `ore-git-ref` line:
+
+```yaml
+- uses: appraisal-rb/setup-ruby-flash@v1
+  with:
+    ore-version: "latest"
+    ore-install: true
+```
+
+## Real-World Use Case: Testing new ore feature branch
+
+**Workflow**:
+
+```yaml
+name: Test new ore feature
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test-with-fix:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/Appraisal.root.gemfile
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Ruby with ore fix
+        uses: appraisal-rb/setup-ruby-flash@main
+        with:
+          ruby-version: "3.4"
+          ore-install: true
+          # Use ore with a feature before it's released
+          ore-git-ref: "feat/a-good-feature"
+
+      - name: Verify fix works
+        run: |
+          ore install
+          test -f Appraisal.root.gemfile.lock
+```
+
+## Summary
+
+The `rv-git-ref` and `ore-git-ref` inputs provide a powerful way to test unreleased versions of rv and ore directly in CI without creating formal releases. This is especially useful for:
+
+- ✅ Testing PR changes before merge
+- ✅ Validating bug fixes in feature branches
+- ✅ Testing pre-release versions (alpha/beta tags)
+- ✅ Reproducing issues with specific commits
+- ✅ Developing setup-ruby-flash itself
+
+While slower on first run, caching makes subsequent runs fast, making this a practical option for testing workflows.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 - You, possibly
 
-[![CI](https://github.com/appraisal-rb/setup-ruby-flash/actions/workflows/ci.yml/badge.svg)](https://github.com/appraisal-rb/setup-ruby-flash/actions/workflows/ci.yml)  [![GitHub tag (latest SemVer)][⛳️tag-img]][⛳️tag] [![License: MIT][📄license-img]][📄license-ref]
+[![CI](https://github.com/appraisal-rb/setup-ruby-flash/actions/workflows/ci.yml/badge.svg)](https://github.com/appraisal-rb/setup-ruby-flash/actions/workflows/ci.yml) [![GitHub tag (latest SemVer)][⛳️tag-img]][⛳️tag] [![License: MIT][📄license-img]][📄license-ref]
 
 [⛳️tag-img]: https://img.shields.io/github/tag/appraisal-rb/setup-ruby-flash.svg
 [⛳️tag]: http://github.com/appraisal-rb/setup-ruby-flash/releases
@@ -44,10 +44,10 @@ A _fast_ GitHub Action for fast Ruby environment setup using [rv](https://github
 - **Architectures**: x86_64, ARM64
 - **Ruby Versions**: 3.2, 3.3, 3.4, 4.0
 
-| # | Important                    | Alternative                   |
-|---|------------------------------|-------------------------------|
-| 1 | Windows is not supported     | [ruby/setup-ruby][setup-ruby] |
-| 2 | Ruby <= 3.1 is not supported | [ruby/setup-ruby][setup-ruby] |
+| #   | Important                    | Alternative                   |
+| --- | ---------------------------- | ----------------------------- |
+| 1   | Windows is not supported     | [ruby/setup-ruby][setup-ruby] |
+| 2   | Ruby <= 3.1 is not supported | [ruby/setup-ruby][setup-ruby] |
 
 [setup-ruby]: https://github.com/ruby/setup-ruby
 
@@ -57,7 +57,7 @@ A _fast_ GitHub Action for fast Ruby environment setup using [rv](https://github
     <summary>Click to see historical background around why I built this</summary>
 
 | 📍 NOTE                                                                                                                                                                                                       |
-|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | RubyGems (the [GitHub org][rubygems-org], not the website) [suffered][draper-security] a [hostile takeover][ellen-takeover] in September 2025.                                                                |
 | Ultimately [4 maintainers][simi-removed] were [hard removed][martin-removed] and an reason has been given for only 1 of those, while 2 others resigned in protest.                                            |
 | It is a [complicated story][draper-takeover] which is difficult to [parse quickly][draper-lies].                                                                                                              |
@@ -98,7 +98,7 @@ A _fast_ GitHub Action for fast Ruby environment setup using [rv](https://github
 ```yaml
 - uses: appraisal-rb/setup-ruby-flash@v1
   with:
-    ruby-version: '3.4'
+    ruby-version: "3.4"
 ```
 
 ### With Gem Installation
@@ -106,7 +106,7 @@ A _fast_ GitHub Action for fast Ruby environment setup using [rv](https://github
 ```yaml
 - uses: appraisal-rb/setup-ruby-flash@v1
   with:
-    ruby-version: '3.4'
+    ruby-version: "3.4"
     ore-install: true
 ```
 
@@ -127,15 +127,17 @@ When `ruby-version` is set to `default` (the default), setup-ruby-flash reads fr
 ## Inputs
 
 | Input                  | Description                                                                                                                    | Default               |
-|------------------------|--------------------------------------------------------------------------------------------------------------------------------|-----------------------|
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------ | --------------------- |
 | `ruby-version`         | Ruby version to install (e.g., `3.4`, `3.4.1`). Use `ruby` for latest stable version, or `default` to read from version files. | `default`             |
 | `rubygems`             | RubyGems version: `default`, `latest`, or a version number (e.g., `3.5.0`)                                                     | `default`             |
 | `bundler`              | Bundler version: `Gemfile.lock`, `default`, `latest`, `none`, or a version number                                              | `Gemfile.lock`        |
 | `ore-install`          | Run `ore install` and cache gems                                                                                               | `false`               |
 | `working-directory`    | Directory for version files and Gemfile                                                                                        | `.`                   |
 | `cache-version`        | Cache version string for invalidation                                                                                          | `v1`                  |
-| `rv-version`           | Version of rv to install                                                                                                       | `latest`              |
-| `ore-version`          | Version of ore to install                                                                                                      | `latest`              |
+| `rv-version`           | Version of rv to install (ignored if `rv-git-ref` is set)                                                                      | `latest`              |
+| `rv-git-ref`           | Git branch, tag, or commit SHA to build rv from source                                                                         | `''`                  |
+| `ore-version`          | Version of ore to install (ignored if `ore-git-ref` is set)                                                                    | `latest`              |
+| `ore-git-ref`          | Git branch, tag, or commit SHA to build ore from source                                                                        | `''`                  |
 | `skip-extensions`      | Skip building native extensions                                                                                                | `false`               |
 | `without-groups`       | Gem groups to exclude (comma-separated)                                                                                        | `''`                  |
 | `ruby-install-retries` | Number of retry attempts for Ruby installation (with exponential backoff)                                                      | `3`                   |
@@ -144,7 +146,7 @@ When `ruby-version` is set to `default` (the default), setup-ruby-flash reads fr
 ## Outputs
 
 | Output             | Description                           |
-|--------------------|---------------------------------------|
+| ------------------ | ------------------------------------- |
 | `ruby-version`     | The installed Ruby version            |
 | `ruby-prefix`      | The path to the Ruby installation     |
 | `rv-version`       | The installed rv version              |
@@ -167,7 +169,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: ['3.2', '3.3', '3.4']
+        ruby: ["3.2", "3.3", "3.4"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
@@ -183,9 +185,9 @@ jobs:
 ```yaml
 - uses: appraisal-rb/setup-ruby-flash@v1
   with:
-    ruby-version: '3.4'
+    ruby-version: "3.4"
     ore-install: true
-    without-groups: 'development,test'
+    without-groups: "development,test"
 ```
 
 ### Latest Ruby with Latest RubyGems and Bundler
@@ -204,8 +206,8 @@ jobs:
 ```yaml
 - uses: appraisal-rb/setup-ruby-flash@v1
   with:
-    ruby-version: '3.4'
-    rubygems: '3.5.0'
+    ruby-version: "3.4"
+    rubygems: "3.5.0"
     ore-install: true
 ```
 
@@ -214,7 +216,7 @@ jobs:
 ```yaml
 - uses: appraisal-rb/setup-ruby-flash@v1
   with:
-    ruby-version: '3.4'
+    ruby-version: "3.4"
     ore-install: true
     skip-extensions: true
 ```
@@ -224,9 +226,9 @@ jobs:
 ```yaml
 - uses: appraisal-rb/setup-ruby-flash@v1
   with:
-    ruby-version: '3.4'
+    ruby-version: "3.4"
     ore-install: true
-    working-directory: './my-app'
+    working-directory: "./my-app"
 ```
 
 ### Specific Tool Versions
@@ -234,9 +236,9 @@ jobs:
 ```yaml
 - uses: appraisal-rb/setup-ruby-flash@v1
   with:
-    ruby-version: '3.4.1'
-    rv-version: '0.4.0'
-    ore-version: '0.1.0'
+    ruby-version: "3.4.1"
+    rv-version: "0.4.0"
+    ore-version: "0.1.0"
     ore-install: true
 ```
 
@@ -247,9 +249,42 @@ If you experience intermittent failures due to GitHub API rate limiting, you can
 ```yaml
 - uses: appraisal-rb/setup-ruby-flash@v1
   with:
-    ruby-version: '3.4'
-    ruby-install-retries: '5'
+    ruby-version: "3.4"
+    ruby-install-retries: "5"
 ```
+
+### Building rv or ore from Source
+
+You can build rv or ore from a git branch, tag, or commit SHA instead of using a released version.
+This is useful for testing unreleased features or bug fixes. Required toolchains (Rust for rv, Go for ore)
+are automatically installed.
+
+```yaml
+# Test an ore feature branch
+- uses: appraisal-rb/setup-ruby-flash@v1
+  with:
+    ruby-version: "3.4"
+    ore-install: true
+    ore-git-ref: "feat/bundle-gemfile-support"
+
+# Test a pre-release rv tag
+- uses: appraisal-rb/setup-ruby-flash@v1
+  with:
+    ruby-version: "3.4"
+    rv-git-ref: "v0.5.0-beta1"
+
+# Test both from main branches
+- uses: appraisal-rb/setup-ruby-flash@v1
+  with:
+    ruby-version: "3.4"
+    rv-git-ref: "main"
+    ore-install: true
+    ore-git-ref: "main"
+```
+
+> **Note**: Building from source is slower on first run (~3-5 min for rv, ~1-2 min for ore) but cached for subsequent runs.
+> Use release versions for production CI workflows.
+> See [GIT_REF_FEATURE.md](GIT_REF_FEATURE.md) for comprehensive documentation.
 
 ## Migration from setup-ruby
 
@@ -259,14 +294,14 @@ setup-ruby-flash is designed to be a near drop-in replacement for `ruby/setup-ru
 # Before (setup-ruby)
 - uses: ruby/setup-ruby@v1
   with:
-    ruby-version: '3.4'
+    ruby-version: "3.4"
     bundler-cache: true
 - run: bundle exec rake test
 
 # After (setup-ruby-flash)
 - uses: appraisal-rb/setup-ruby-flash@v1
   with:
-    ruby-version: '3.4'
+    ruby-version: "3.4"
     ore-install: true
 - run: bundle exec rake test
 ```
@@ -291,18 +326,18 @@ setup-ruby-flash is designed to be a near drop-in replacement for `ruby/setup-ru
 
 ### Key Differences
 
-| Feature              | setup-ruby      | setup-ruby-flash  |
-|----------------------|-----------------|-------------------|
-| Ruby Install         | ~5 seconds      | < 2 seconds       |
-| Gem Install          | Bundler         | ore (~50% faster) |
-| `ruby-version: ruby` | ✅ latest stable | ✅ latest stable   |
-| `rubygems: latest`   | ✅               | ✅                 |
-| `bundler: latest`    | ✅               | ✅                 |
-| Windows              | ✅               | ❌                 |
-| Ruby < 3.2           | ✅               | ❌                 |
-| JRuby                | ✅               | ❌ (planned)       |
-| TruffleRuby          | ✅               | ❌ (planned)       |
-| Security Audit       | ❌               | ✅ (`ore audit`)   |
+| Feature              | setup-ruby       | setup-ruby-flash  |
+| -------------------- | ---------------- | ----------------- |
+| Ruby Install         | ~5 seconds       | < 2 seconds       |
+| Gem Install          | Bundler          | ore (~50% faster) |
+| `ruby-version: ruby` | ✅ latest stable | ✅ latest stable  |
+| `rubygems: latest`   | ✅               | ✅                |
+| `bundler: latest`    | ✅               | ✅                |
+| Windows              | ✅               | ❌                |
+| Ruby < 3.2           | ✅               | ❌                |
+| JRuby                | ✅               | ❌ (planned)      |
+| TruffleRuby          | ✅               | ❌ (planned)      |
+| Security Audit       | ❌               | ✅ (`ore audit`)  |
 
 ## About rv and ore
 
@@ -387,7 +422,7 @@ You may use the software for the benefit of your company if it meets all these c
 
 3.  received less than $1,000,000 total debt, equity, and other investment in the last five tax years, counting investment in predecessor companies that reorganized into, merged with, or spun out your company
 
-All dollar figures are United States dollars as of 2019.  Adjust them for inflation according to the United States Bureau of Labor Statistics' consumer price index for all urban consumers, United States city average, for all items, not seasonally adjusted, with 1982–1984=100 reference base.
+All dollar figures are United States dollars as of 2019. Adjust them for inflation according to the United States Bureau of Labor Statistics' consumer price index for all urban consumers, United States city average, for all items, not seasonally adjusted, with 1982–1984=100 reference base.
 
 ### Big Business
 
@@ -416,7 +451,7 @@ and [ore][ore] / [Contriboss](https://github.com/contriboss), as this project wo
 
 #### How to Request
 
-Request a fair commercial license by sending an email to [peter@9thbit.net](mailto:peter@9thbit.net) _and_ messaging the `#org-appraisal-rb` channel on the Official Discord 👉️ [![Live Chat on Discord][✉️discord-invite-img]][✉️discord-invite].  If both of your contact attempts fail to elicit a response within the time period allotted in [Big Business][big-business] the licensor will consider that equivalent to a fair commercial license under [Big Business][big-business].
+Request a fair commercial license by sending an email to [peter@9thbit.net](mailto:peter@9thbit.net) _and_ messaging the `#org-appraisal-rb` channel on the Official Discord 👉️ [![Live Chat on Discord][✉️discord-invite-img]][✉️discord-invite]. If both of your contact attempts fail to elicit a response within the time period allotted in [Big Business][big-business] the licensor will consider that equivalent to a fair commercial license under [Big Business][big-business].
 
 # 🤑 A request for help
 

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,10 @@
-name: 'Setup Ruby with rv and ore'
-description: 'Fast Ruby environment setup using rv for Ruby installation and ore for gem management'
-author: 'appraisal-rb'
+name: "Setup Ruby with rv and ore"
+description: "Fast Ruby environment setup using rv for Ruby installation and ore for gem management"
+author: "appraisal-rb"
 
 branding:
-  icon: 'zap'
-  color: 'red'
+  icon: "zap"
+  color: "red"
 
 inputs:
   ruby-version:
@@ -13,7 +13,7 @@ inputs:
       Use 'ruby' for latest stable MRI Ruby version.
       Supported versions: 3.2, 3.3, 3.4, 4.0
     required: false
-    default: 'default'
+    default: "default"
 
   rubygems:
     description: |
@@ -22,7 +22,7 @@ inputs:
       For 'latest', `gem update --system` is run to update to the latest compatible RubyGems version.
       If a version number is given, `gem update --system <version>` is run to update to that version.
     required: false
-    default: 'default'
+    default: "default"
 
   bundler:
     description: |
@@ -32,59 +32,79 @@ inputs:
       For 'latest', installs the latest compatible Bundler version (Bundler 2 on Ruby 3.2+).
       For 'none', nothing is done.
     required: false
-    default: 'Gemfile.lock'
+    default: "Gemfile.lock"
 
   ore-install:
     description: |
       Run "ore install" to install gems and cache them automatically.
       Either 'true' or 'false'.
     required: false
-    default: 'false'
+    default: "false"
 
   working-directory:
     description: |
       Working directory for resolving version files (.ruby-version, etc.) and Gemfile.
     required: false
-    default: '.'
+    default: "."
 
   cache-version:
     description: |
       Cache version string. Change this to invalidate caches when needed.
     required: false
-    default: 'v1'
+    default: "v1"
 
   rv-version:
     description: |
       Version of rv to install. Either 'latest' or a specific version (e.g., '0.4.0').
+      Ignored if rv-git-ref is set.
     required: false
-    default: 'latest'
+    default: "latest"
+
+  rv-git-ref:
+    description: |
+      Git branch, tag, or commit SHA to build rv from source.
+      When set, rv will be built from the specified git ref instead of using a release.
+      Example: 'main', 'feat/new-feature', 'v0.5.0-beta'
+      Rust toolchain is automatically installed if needed.
+    required: false
+    default: ""
 
   ore-version:
     description: |
       Version of ore to install. Either 'latest' or a specific version (e.g., '0.1.0').
+      Ignored if ore-git-ref is set.
     required: false
-    default: 'latest'
+    default: "latest"
+
+  ore-git-ref:
+    description: |
+      Git branch, tag, or commit SHA to build ore from source.
+      When set, ore will be built from the specified git ref instead of using a release.
+      Example: 'main', 'feat/a-cool-feature', 'v0.19.0-alpha'
+      Go toolchain is automatically installed if needed.
+    required: false
+    default: ""
 
   skip-extensions:
     description: |
       Skip building native extensions during gem installation.
       Either 'true' or 'false'.
     required: false
-    default: 'false'
+    default: "false"
 
   without-groups:
     description: |
       Gem groups to exclude from installation (comma-separated).
       Example: 'development,test'
     required: false
-    default: ''
+    default: ""
 
   ruby-install-retries:
     description: |
       Number of retry attempts for Ruby installation if it fails (e.g., due to GitHub API rate limiting).
       Uses exponential backoff between retries.
     required: false
-    default: '3'
+    default: "3"
 
   token:
     description: |
@@ -95,35 +115,35 @@ inputs:
 
 outputs:
   ruby-version:
-    description: 'The installed Ruby version'
+    description: "The installed Ruby version"
     value: ${{ steps.setup.outputs.ruby-version }}
 
   ruby-prefix:
-    description: 'The prefix/path of the installed Ruby'
+    description: "The prefix/path of the installed Ruby"
     value: ${{ steps.setup.outputs.ruby-prefix }}
 
   rv-version:
-    description: 'The installed rv version'
+    description: "The installed rv version"
     value: ${{ steps.setup.outputs.rv-version }}
 
   rubygems-version:
-    description: 'The installed RubyGems version'
+    description: "The installed RubyGems version"
     value: ${{ steps.configure-rubygems.outputs.version || steps.setup.outputs.gem-version }}
 
   bundler-version:
-    description: 'The installed Bundler version'
+    description: "The installed Bundler version"
     value: ${{ steps.install-bundler.outputs.version || 'default' }}
 
   ore-version:
-    description: 'The installed ore version (if ore-install is true)'
+    description: "The installed ore version (if ore-install is true)"
     value: ${{ steps.setup.outputs.ore-version }}
 
   cache-hit:
-    description: 'Whether gems were restored from cache'
+    description: "Whether gems were restored from cache"
     value: ${{ steps.setup.outputs.cache-hit }}
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Validate platform
       id: platform
@@ -162,10 +182,17 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.token }}
       run: |
-        if [ "${{ inputs.rv-version }}" = "latest" ]; then
+        # If git ref is specified, use it for cache key
+        if [ -n "${{ inputs.rv-git-ref }}" ]; then
+          VERSION="${{ inputs.rv-git-ref }}"
+          echo "build-from-source=true" >> $GITHUB_OUTPUT
+          echo "Using rv git ref: $VERSION (will build from source)"
+        elif [ "${{ inputs.rv-version }}" = "latest" ]; then
           VERSION=$(gh api repos/spinel-coop/rv/releases/latest --jq '.tag_name' 2>/dev/null || echo "v0.4.1")
+          echo "build-from-source=false" >> $GITHUB_OUTPUT
         else
           VERSION="${{ inputs.rv-version }}"
+          echo "build-from-source=false" >> $GITHUB_OUTPUT
         fi
         VERSION="${VERSION#v}"
         echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -176,10 +203,47 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.local/bin/rv
-        key: setup-ruby-flash-rv-${{ steps.platform.outputs.platform }}-${{ steps.rv-version.outputs.version }}
+        key: setup-ruby-flash-rv-${{ steps.platform.outputs.platform }}-${{ steps.rv-version.outputs.version }}-${{ steps.rv-version.outputs.build-from-source }}
 
-    - name: Install rv
-      if: steps.cache-rv.outputs.cache-hit != 'true'
+    - name: Setup Rust toolchain for rv
+      if: steps.cache-rv.outputs.cache-hit != 'true' && steps.rv-version.outputs.build-from-source == 'true'
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Build rv from source
+      if: steps.cache-rv.outputs.cache-hit != 'true' && steps.rv-version.outputs.build-from-source == 'true'
+      shell: bash
+      run: |
+        GIT_REF="${{ inputs.rv-git-ref }}"
+        echo "Building rv from source (git ref: $GIT_REF)..."
+
+        # Clone rv repository (shallow clone for speed)
+        git clone --depth 1 https://github.com/spinel-coop/rv.git /tmp/rv-build
+        cd /tmp/rv-build
+        # Fetch the specific ref if shallow clone doesn't have it
+        if ! git checkout "$GIT_REF" 2>/dev/null; then
+          git fetch --depth 1 origin "$GIT_REF"
+          if ! git checkout FETCH_HEAD; then
+            echo "::error::Failed to checkout rv git ref: $GIT_REF"
+            exit 1
+          fi
+        fi
+
+        # Build rv using cargo
+        cargo build --release
+
+        # Install to ~/.local/bin
+        mkdir -p ~/.local/bin
+        cp target/release/rv ~/.local/bin/rv
+        chmod +x ~/.local/bin/rv
+
+        echo "Built and installed rv from $GIT_REF"
+        ~/.local/bin/rv --version
+
+        # Cleanup build directory
+        rm -rf /tmp/rv-build
+
+    - name: Install rv from release
+      if: steps.cache-rv.outputs.cache-hit != 'true' && steps.rv-version.outputs.build-from-source == 'false'
       shell: bash
       run: |
         VERSION="${{ steps.rv-version.outputs.version }}"
@@ -267,7 +331,7 @@ runs:
         fi
         mkdir -p "$RV_CACHE_DIR"
         CACHE_FILE="$RV_CACHE_DIR/available_rubies.json"
-        
+
         echo "Fetching Ruby releases list with authenticated API call..."
         RESPONSE=$(curl -fsSL \
           -H "Authorization: Bearer $GITHUB_TOKEN" \
@@ -275,7 +339,7 @@ runs:
           -H "User-Agent: rv-cli" \
           -D /tmp/headers.txt \
           "https://api.github.com/repos/spinel-coop/rv-ruby/releases/latest" 2>/dev/null) || true
-        
+
         if [ -n "$RESPONSE" ]; then
           # Extract ETag from headers - GitHub sends it with quotes like: etag: "abc123" or W/"abc123"
           RAW_ETAG=$(grep -i '^etag:' /tmp/headers.txt | tr -d '\r' | sed 's/^[eE][tT][aA][gG]: *//' || echo "")
@@ -326,16 +390,16 @@ runs:
       shell: bash
       run: |
         RUBY_VERSION="${{ steps.detect-ruby.outputs.version }}"
-        
+
         # Use rv to find the installed Ruby executable path
         RUBY_EXECUTABLE=$(~/.local/bin/rv ruby find "$RUBY_VERSION" 2>/dev/null)
-        
+
         if [ -z "$RUBY_EXECUTABLE" ]; then
           echo "::error::Could not find Ruby $RUBY_VERSION installation"
           ~/.local/bin/rv ruby list || true
           exit 1
         fi
-        
+
         # Get the bin directory from the executable path
         RUBY_BIN_DIR=$(dirname "$RUBY_EXECUTABLE")
         RUBY_PREFIX=$(dirname "$RUBY_BIN_DIR")
@@ -348,7 +412,7 @@ runs:
         export PATH="$RUBY_BIN_DIR:$PATH"
         FULL_RUBY_VERSION=$(ruby -e 'print RUBY_VERSION')
         GEM_VERSION=$(gem --version)
-        
+
         # Set outputs
         echo "ruby-version=$RUBY_VERSION" >> $GITHUB_OUTPUT
         echo "ruby-full-version=$FULL_RUBY_VERSION" >> $GITHUB_OUTPUT
@@ -395,13 +459,13 @@ runs:
       run: |
         BUNDLER_INPUT="${{ inputs.bundler }}"
         RUBY_VERSION="${{ steps.setup.outputs.ruby-full-version }}"
-        
+
         # Helper function to check if a specific bundler version is installed
         is_bundler_installed() {
           local version="$1"
           gem list bundler --installed --version "$version" >/dev/null 2>&1
         }
-        
+
         # Helper function to check if bundler satisfies a version requirement
         bundler_satisfies() {
           local required="$1"
@@ -416,13 +480,13 @@ runs:
             [ "$required" = "$current" ]
           fi
         }
-        
+
         # Get currently installed bundler version
         CURRENT_BUNDLER=$(bundle --version 2>/dev/null | awk '{print $NF}' || echo "")
         if [ -n "$CURRENT_BUNDLER" ]; then
           echo "Current Bundler version: $CURRENT_BUNDLER"
         fi
-        
+
         # Determine Bundler version to install
         if [ "$BUNDLER_INPUT" = "Gemfile.lock" ]; then
           if [ -f "Gemfile.lock" ]; then
@@ -445,7 +509,7 @@ runs:
             BUNDLER_INPUT="default"
           fi
         fi
-        
+
         if [ "$BUNDLER_INPUT" = "default" ]; then
           # Ruby 3.2+ ships with Bundler 2.2+, use it
           if [ -n "$CURRENT_BUNDLER" ]; then
@@ -455,7 +519,7 @@ runs:
           fi
           BUNDLER_INPUT="latest"
         fi
-        
+
         if [ "$BUNDLER_INPUT" = "latest" ]; then
           # Check if we already have a recent bundler
           if [ -n "$CURRENT_BUNDLER" ]; then
@@ -510,7 +574,7 @@ runs:
         if [ -z "$BUNDLER_VERSION" ]; then
           BUNDLER_VERSION=$(bundle --version 2>/dev/null | awk '{print $NF}' || echo "default")
         fi
-        
+
         echo "### setup-ruby-flash Summary ⚡" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "| Component | Value |" >> $GITHUB_STEP_SUMMARY
@@ -529,10 +593,17 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.token }}
       run: |
-        if [ "${{ inputs.ore-version }}" = "latest" ]; then
+        # If git ref is specified, use it for cache key
+        if [ -n "${{ inputs.ore-git-ref }}" ]; then
+          VERSION="${{ inputs.ore-git-ref }}"
+          echo "build-from-source=true" >> $GITHUB_OUTPUT
+          echo "Using ore git ref: $VERSION (will build from source)"
+        elif [ "${{ inputs.ore-version }}" = "latest" ]; then
           VERSION=$(gh api repos/contriboss/ore-light/releases/latest --jq '.tag_name' 2>/dev/null || echo "v0.18.0")
+          echo "build-from-source=false" >> $GITHUB_OUTPUT
         else
           VERSION="${{ inputs.ore-version }}"
+          echo "build-from-source=false" >> $GITHUB_OUTPUT
         fi
         VERSION="${VERSION#v}"
         echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -544,10 +615,49 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.local/bin/ore
-        key: setup-ruby-flash-ore-${{ steps.platform.outputs.platform }}-${{ steps.ore-version.outputs.version }}
+        key: setup-ruby-flash-ore-${{ steps.platform.outputs.platform }}-${{ steps.ore-version.outputs.version }}-${{ steps.ore-version.outputs.build-from-source }}
 
-    - name: Install ore
-      if: inputs.ore-install == 'true' && steps.cache-ore.outputs.cache-hit != 'true'
+    - name: Setup Go toolchain for ore
+      if: inputs.ore-install == 'true' && steps.cache-ore.outputs.cache-hit != 'true' && steps.ore-version.outputs.build-from-source == 'true'
+      uses: actions/setup-go@v5
+      with:
+        go-version: "stable"
+
+    - name: Build ore from source
+      if: inputs.ore-install == 'true' && steps.cache-ore.outputs.cache-hit != 'true' && steps.ore-version.outputs.build-from-source == 'true'
+      shell: bash
+      run: |
+        GIT_REF="${{ inputs.ore-git-ref }}"
+        echo "Building ore from source (git ref: $GIT_REF)..."
+
+        # Clone ore-light repository (shallow clone for speed)
+        git clone --depth 1 https://github.com/contriboss/ore-light.git /tmp/ore-build
+        cd /tmp/ore-build
+        # Fetch the specific ref if shallow clone doesn't have it
+        if ! git checkout "$GIT_REF" 2>/dev/null; then
+          git fetch --depth 1 origin "$GIT_REF"
+          if ! git checkout FETCH_HEAD; then
+            echo "::error::Failed to checkout ore git ref: $GIT_REF"
+            exit 1
+          fi
+        fi
+
+        # Build ore using Go
+        go build -o ore ./cmd/ore
+
+        # Install to ~/.local/bin
+        mkdir -p ~/.local/bin
+        cp ore ~/.local/bin/ore
+        chmod +x ~/.local/bin/ore
+
+        echo "Built and installed ore from $GIT_REF"
+        ~/.local/bin/ore --version
+
+        # Cleanup build directory
+        rm -rf /tmp/ore-build
+
+    - name: Install ore from release
+      if: inputs.ore-install == 'true' && steps.cache-ore.outputs.cache-hit != 'true' && steps.ore-version.outputs.build-from-source == 'false'
       shell: bash
       run: |
         VERSION="${{ steps.ore-version.outputs.version }}"
@@ -585,7 +695,6 @@ runs:
         key: ${{ steps.gem-cache-key.outputs.key }}
         restore-keys: ${{ steps.gem-cache-key.outputs.restore-keys }}
 
-
     - name: Install gems with ore
       if: inputs.ore-install == 'true'
       id: install-gems
@@ -599,12 +708,12 @@ runs:
       run: |
         # Ensure we're using the rv-installed Ruby
         export PATH="${{ steps.setup.outputs.ruby-prefix }}/bin:$PATH"
-        
+
         # Verify we're using the right Ruby
         echo "Using Ruby: $(which ruby)"
         echo "Ruby version: $(ruby --version)"
         echo "GEM_HOME: $GEM_HOME"
-        
+
         # Build ore install command
         INSTALL_CMD="ore install"
         if [ "${{ inputs.skip-extensions }}" = "true" ]; then


### PR DESCRIPTION
### Added

- **Build from Source Support**: New `rv-git-ref` and `ore-git-ref` inputs allow building rv and ore from git branches, tags, or commits instead of using release binaries
  - `rv-git-ref`: Build rv from any git reference (requires Rust, automatically installed)
  - `ore-git-ref`: Build ore from any git reference (requires Go 1.24, automatically installed)
  - Enables testing unreleased versions without creating formal releases
  - Supports branches (`main`), tags (`v0.5.0-beta`), and commit SHAs
  - Built binaries are cached by git ref for fast subsequent runs
  - When git ref is set, corresponding version input (`rv-version`, `ore-version`) is ignored
  - **Use Case**: Test PRs, feature branches, and bug fixes before release
  - **Performance**: First build 3-5 min (rv) or 1-2 min (ore); cached builds ~1-2 sec
  - See `GIT_REF_FEATURE.md` for comprehensive documentation and examples

### Changed

- Cache keys now include `build-from-source` flag to prevent collision between git refs and release versions
- Improved version resolution to handle both release versions and git references

### Notes

- Building from source is intended for testing only; production CI should use release versions
- Rust toolchain installed automatically for rv (via `dtolnay/rust-toolchain@stable`)
- Go toolchain installed automatically for ore (via `actions/setup-go@v5` with `stable`)

---

## Usage Example

Test unreleased ore fix:

```yaml
- uses: appraisal-rb/setup-ruby-flash@v1
  with:
    ruby-version: "3.4"
    ore-install: true
    ore-git-ref: "feat/bundle-gemfile-support" # Build from feature branch
```

Test rv pre-release:

```yaml
- uses: appraisal-rb/setup-ruby-flash@v1
  with:
    ruby-version: "3.4"
    rv-git-ref: "v0.5.0-beta1" # Build from beta tag
```
