### PR TITLE
✨ ore-setup option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           # Need GH Token Authenticated requests, switch once the feature is released
           rv-git-ref: 'main'
           # Build both ore and gemfile-go from main
-          ore-git-ref: 'feat/debugging'
+          ore-git-ref: 'master'
           gfgo-git-ref: 'master'
 
       - name: Verify Ruby installation
@@ -88,7 +88,7 @@ jobs:
           # Need GH Token Authenticated requests, switch once the feature is released
           rv-git-ref: 'main'
           # Build both ore and gemfile-go from main
-          ore-git-ref: 'feat/debugging'
+          ore-git-ref: 'master'
           gfgo-git-ref: 'master'
 
       - name: Verify ore installation
@@ -140,7 +140,7 @@ jobs:
           # Need GH Token Authenticated requests, switch once the feature is released
           rv-git-ref: 'main'
           # Build both ore and gemfile-go from main
-          ore-git-ref: 'feat/debugging'
+          ore-git-ref: 'master'
           gfgo-git-ref: 'master'
 
       - name: Ensure ore is installed (diagnostic)
@@ -240,7 +240,7 @@ jobs:
           # Need GH Token Authenticated requests, switch once the feature is released
           rv-git-ref: 'main'
           # Build both ore and gemfile-go from main
-          ore-git-ref: 'feat/debugging'
+          ore-git-ref: 'master'
           gfgo-git-ref: 'master'
 
       - name: Ensure ore is installed (diagnostic)
@@ -350,7 +350,7 @@ jobs:
           # Need GH Token Authenticated requests, switch once the feature is released
           rv-git-ref: 'main'
           # Build both ore and gemfile-go from main
-          ore-git-ref: 'feat/debugging'
+          ore-git-ref: 'master'
           gfgo-git-ref: 'master'
 
       - name: Run acceptance tests
@@ -373,7 +373,7 @@ jobs:
           # Need GH Token Authenticated requests, switch once the feature is released
           rv-git-ref: 'main'
           # Build both ore and gemfile-go from main
-          ore-git-ref: 'feat/debugging'
+          ore-git-ref: 'master'
           gfgo-git-ref: 'master'
 
       - name: Run RuboCop
@@ -408,7 +408,7 @@ jobs:
           # Need GH Token Authenticated requests, switch once the feature is released
           rv-git-ref: 'main'
           # Build both ore and gemfile-go from main
-          ore-git-ref: 'feat/debugging'
+          ore-git-ref: 'master'
           gfgo-git-ref: 'master'
 
       - name: Verify ore installation

--- a/.github/workflows/runtime-heads.yml
+++ b/.github/workflows/runtime-heads.yml
@@ -45,7 +45,7 @@ jobs:
           # Need GH Token Authenticated requests, switch once the feature is released
           rv-git-ref: 'main'
           # Build both ore and gemfile-go from main
-          ore-git-ref: 'feat/debugging'
+          ore-git-ref: 'master'
           gfgo-git-ref: 'master'
 
       - name: Verify ore installation

--- a/README.md
+++ b/README.md
@@ -137,6 +137,24 @@ For easy migration from ruby/setup-ruby, use `bundler-cache` (works the same as 
     bundler-cache: true
 ```
 
+### Manual Ore Commands
+
+Install ore without running `ore install` automatically, allowing manual ore commands:
+
+```yaml
+- uses: appraisal-rb/setup-ruby-flash@v1
+  with:
+    ruby-version: "3.4"
+    ore-setup: true      # Install ore binary
+    ore-install: false   # Don't auto-install gems
+
+- name: Custom ore workflow
+  run: |
+    ore fetch --all
+    ore check --verbose
+    ore list
+```
+
 ### Using Version Files
 
 When `ruby-version` is set to `default` (the default), setup-ruby-flash reads from:
@@ -158,7 +176,8 @@ When `ruby-version` is set to `default` (the default), setup-ruby-flash reads fr
 | `ruby-version`         | Ruby version to install (e.g., `3.4`, `3.4.1`). Use `ruby` for latest stable version, or `default` to read from version files. | `default`             |
 | `rubygems`             | RubyGems version: `default`, `latest`, or a version number (e.g., `3.5.0`)                                                     | `default`             |
 | `bundler`              | Bundler version: `Gemfile.lock`, `default`, `latest`, `none`, or a version number                                              | `Gemfile.lock`        |
-| `ore-install`          | Run `ore install` and cache gems                                                                                               | `false`               |
+| `ore-setup`            | Install ore binary: `true`, `false`, or `auto` (installs if `ore-install` or `bundler-cache` is enabled)                       | `auto`                |
+| `ore-install`          | Run `ore install` command to install gems from lockfile (requires ore to be installed)                                         | `false`               |
 | `bundler-cache`        | Enable Bundler caching (alias for `ore-install` for compatibility with ruby/setup-ruby)                                        | `false`               |
 | `working-directory`    | Directory for version files and Gemfile                                                                                        | `.`                   |
 | `cache-version`        | Cache version string for invalidation                                                                                          | `v1`                  |

--- a/action.yml
+++ b/action.yml
@@ -34,10 +34,23 @@ inputs:
     required: false
     default: "Gemfile.lock"
 
+  ore-setup:
+    description: |
+      Install ore (the gem manager) in the environment.
+      Either 'true', 'false', or 'auto' (default).
+      When 'auto', ore is installed if ore-install or bundler-cache is true.
+      When 'true', ore is always installed even if ore-install is false.
+      When 'false', ore is never installed.
+      Use 'true' when you want ore available but will run ore commands manually.
+    required: false
+    default: "auto"
+
   ore-install:
     description: |
-      Run "ore install" to install gems and cache them automatically.
+      Run "ore install" command to install gems from lockfile.
       Either 'true' or 'false'.
+      Note: Requires ore-setup to be 'true' or 'auto' (with bundler-cache enabled).
+      When false, gems are not installed automatically, but ore will still be available if ore-setup is true.
     required: false
     default: "false"
 
@@ -801,7 +814,7 @@ runs:
         fi
 
     - name: Generate summary (Ruby only)
-      if: steps.check-support.outputs.use-fallback != 'true' && inputs.ore-install != 'true' && inputs.bundler-cache != 'true'
+      if: steps.check-support.outputs.use-fallback != 'true' && steps.should-install-ore.outputs.install-ore != 'true'
       shell: bash
       run: |
         RUBYGEMS_VERSION="${{ steps.configure-rubygems.outputs.version }}"
@@ -835,8 +848,35 @@ runs:
           echo "| Ruby Install Time | ${{ steps.install-ruby.outputs.install-time }}s |" >> $GITHUB_STEP_SUMMARY
         fi
 
+    - name: Determine if ore should be installed
+      if: steps.check-support.outputs.use-fallback != 'true'
+      id: should-install-ore
+      shell: bash
+      run: |
+        ORE_SETUP="${{ inputs.ore-setup }}"
+        ORE_INSTALL="${{ inputs.ore-install }}"
+        BUNDLER_CACHE="${{ inputs.bundler-cache }}"
+        
+        # Determine if ore should be installed
+        if [ "$ORE_SETUP" = "true" ]; then
+          echo "install-ore=true" >> $GITHUB_OUTPUT
+          echo "Ore will be installed (ore-setup: true)"
+        elif [ "$ORE_SETUP" = "false" ]; then
+          echo "install-ore=false" >> $GITHUB_OUTPUT
+          echo "Ore will NOT be installed (ore-setup: false)"
+        else
+          # auto mode: install if ore-install or bundler-cache is true
+          if [ "$ORE_INSTALL" = "true" ] || [ "$BUNDLER_CACHE" = "true" ]; then
+            echo "install-ore=true" >> $GITHUB_OUTPUT
+            echo "Ore will be installed (ore-setup: auto, ore-install or bundler-cache enabled)"
+          else
+            echo "install-ore=false" >> $GITHUB_OUTPUT
+            echo "Ore will NOT be installed (ore-setup: auto, no gem installation requested)"
+          fi
+        fi
+
     - name: Resolve ore version
-      if: steps.check-support.outputs.use-fallback != 'true' && (inputs.ore-install == 'true' || inputs.bundler-cache == 'true')
+      if: steps.check-support.outputs.use-fallback != 'true' && steps.should-install-ore.outputs.install-ore == 'true'
       id: ore-version
       shell: bash
       env:
@@ -896,7 +936,7 @@ runs:
         fi
 
     - name: Cache ore binary
-      if: steps.check-support.outputs.use-fallback != 'true' && (inputs.ore-install == 'true' || inputs.bundler-cache == 'true')
+      if: steps.check-support.outputs.use-fallback != 'true' && steps.should-install-ore.outputs.install-ore == 'true'
       id: cache-ore
       uses: actions/cache@v4
       with:
@@ -904,13 +944,13 @@ runs:
         key: setup-ruby-flash-ore-${{ steps.platform.outputs.platform }}-ruby-${{ steps.detect-ruby.outputs.version }}-${{ steps.ore-version.outputs.version }}-${{ steps.ore-version.outputs.build-from-source }}-gfgo-${{ steps.ore-version.outputs.gfgo-version }}
 
     - name: Setup Go toolchain for ore
-      if: steps.check-support.outputs.use-fallback != 'true' && (inputs.ore-install == 'true' || inputs.bundler-cache == 'true') && steps.cache-ore.outputs.cache-hit != 'true' && steps.ore-version.outputs.build-from-source == 'true'
+      if: steps.check-support.outputs.use-fallback != 'true' && steps.should-install-ore.outputs.install-ore == 'true' && steps.cache-ore.outputs.cache-hit != 'true' && steps.ore-version.outputs.build-from-source == 'true'
       uses: actions/setup-go@v5
       with:
         go-version: "stable"
 
     - name: Build ore from source
-      if: steps.check-support.outputs.use-fallback != 'true' && (inputs.ore-install == 'true' || inputs.bundler-cache == 'true') && steps.cache-ore.outputs.cache-hit != 'true' && steps.ore-version.outputs.build-from-source == 'true'
+      if: steps.check-support.outputs.use-fallback != 'true' && steps.should-install-ore.outputs.install-ore == 'true' && steps.cache-ore.outputs.cache-hit != 'true' && steps.ore-version.outputs.build-from-source == 'true'
       id: build-ore
       shell: bash
       run: |
@@ -1041,7 +1081,7 @@ runs:
         fi
 
     - name: Install ore from release
-      if: steps.check-support.outputs.use-fallback != 'true' && (inputs.ore-install == 'true' || inputs.bundler-cache == 'true') && steps.cache-ore.outputs.cache-hit != 'true' && steps.ore-version.outputs.build-from-source == 'false'
+      if: steps.check-support.outputs.use-fallback != 'true' && steps.should-install-ore.outputs.install-ore == 'true' && steps.cache-ore.outputs.cache-hit != 'true' && steps.ore-version.outputs.build-from-source == 'false'
       shell: bash
       run: |
         VERSION="${{ steps.ore-version.outputs.version }}"
@@ -1050,7 +1090,7 @@ runs:
         echo "Installed ore $VERSION"
 
     - name: Generate gem cache key
-      if: steps.check-support.outputs.use-fallback != 'true' && (inputs.ore-install == 'true' || inputs.bundler-cache == 'true')
+      if: steps.check-support.outputs.use-fallback != 'true' && steps.should-install-ore.outputs.install-ore == 'true'
       id: gem-cache-key
       shell: bash
       working-directory: ${{ inputs.working-directory }}
@@ -1087,7 +1127,7 @@ runs:
         echo "restore-keys=setup-ruby-flash-gems-${{ inputs.cache-version }}-${{ steps.platform.outputs.platform }}-ruby-${FULL_RUBY}-" >> $GITHUB_OUTPUT
 
     - name: Cache gems
-      if: steps.check-support.outputs.use-fallback != 'true' && (inputs.ore-install == 'true' || inputs.bundler-cache == 'true')
+      if: steps.check-support.outputs.use-fallback != 'true' && steps.should-install-ore.outputs.install-ore == 'true'
       id: cache-gems
       uses: actions/cache@v4
       with:
@@ -1098,7 +1138,7 @@ runs:
         restore-keys: ${{ steps.gem-cache-key.outputs.restore-keys }}
 
     - name: Install gems with ore
-      if: steps.check-support.outputs.use-fallback != 'true' && (inputs.ore-install == 'true' || inputs.bundler-cache == 'true')
+      if: steps.check-support.outputs.use-fallback != 'true' && steps.should-install-ore.outputs.install-ore == 'true' && (inputs.ore-install == 'true' || inputs.bundler-cache == 'true')
       id: install-gems
       shell: bash
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
1. action.yml - New Input
Added ore-setup input with values: 'true', 'false', or 'auto' (default)
Purpose: Explicitly controls whether ore binary is installed
Behavior:
'true': Always install ore, even if ore-install is false
'false': Never install ore
'auto': Install ore only if ore-install or bundler-cache is true (backward compatible)
2. action.yml - Updated ore-install Description
Changed from: "Run 'ore install' to install gems and cache them automatically"
Changed to: "Run 'ore install' command to install gems from lockfile (requires ore to be installed)"
Now accurately describes what the input does
3. action.yml - New Step: "Determine if ore should be installed"
Added logic to evaluate ore-setup input and determine whether to install ore
Sets steps.should-install-ore.outputs.install-ore output (true/false)
This output is used by all ore-related steps
4. action.yml - Updated All Ore-Related Conditionals
Updated conditionals for these steps to use steps.should-install-ore.outputs.install-ore:
"Resolve ore version"
"Cache ore binary"
"Setup Go toolchain for ore"
"Build ore from source"
"Install ore from release"
"Generate gem cache key"
"Cache gems"
5. action.yml - Special Logic for "Install gems with ore"
This step now checks BOTH:
steps.should-install-ore.outputs.install-ore == 'true' (ore is installed)
AND inputs.ore-install == 'true' || inputs.bundler-cache == 'true' (user wants automatic gem installation)
This enables the new use case: ore installed but gems not automatically installed.
6. README.md - Documentation Updates
Added ore-setup to inputs table with description
Updated ore-install description to clarify it runs the command
Added new example showing "Manual Ore Commands" use case
New Capabilities
Before: Users couldn't install ore without also running ore install automatically.
After: Users can now:
Install ore and run ore install automatically (original behavior):
ore-install: true  # or bundler-cache: true
Install ore but run commands manually (NEW):
ore-setup: true
ore-install: false
Not install ore at all (explicit):
ore-setup: false
Backward Compatibility
✅ Fully backward compatible
Default ore-setup: auto maintains existing behavior
Existing workflows require no changes
New capability is opt-in